### PR TITLE
Encode as binary (really, no encoding)

### DIFF
--- a/examples/localmap.js
+++ b/examples/localmap.js
@@ -58,11 +58,11 @@ discover()
 
             var imageFile = fs.createWriteStream('localmap.pgm', {
                 flags: 'w',
-                defaultEncoding: 'ascii',
+                defaultEncoding: 'binary',
                 mode: 0o666
             })
 
-            imageFile.write(`P5 ${map.width} ${map.height} 255\n ${map.pixels.toString('ascii')}`)
+            imageFile.write(`P5 ${map.width} ${map.height} 255\n ${map.pixels.toString('binary')}`)
             console.log('Wrote file');
           })
 


### PR DESCRIPTION
`'ascii'` will strip off the high bit:

https://nodejs.org/api/buffer.html#buffer_buffer

Switch over to `'binary'` and we're good.